### PR TITLE
Add the Synthefy Nori tabular regression model (+ loader fixes for 4 datasets)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 *.png
 *.csv
 *.pdf
+
+# Generated/runtime artifacts
+datasets.json
+output_smoke/
+MONITOR_DONE

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ pytest
 pyarrow
 autorank
 openml
+# Nori wrapper (scoringbench/wrappers/synthefy.py) needs the output_type="full"
+# quantile API, added in synthefy-nori 0.6.0.
+synthefy-nori>=0.6.0

--- a/run_bench_regression.py
+++ b/run_bench_regression.py
@@ -30,6 +30,7 @@ from scoringbench.datasets import get_DATASETS_CONFIG, validate_datasets
 from scoringbench.runner import run_benchmark
 from scoringbench.utils import set_seed
 from scoringbench.wrappers import (
+    SynthefyWrapper,
     TabPFNWrapper,
     FinetuneTabPFNWrapper,
     FinetuneTabICLWrapper,
@@ -133,6 +134,7 @@ dict_finetuned_models = {
 }
 
 MODELS = {
+    "nori": lambda: SynthefyWrapper(),
     f"tabpfn_realv2_5": lambda: TabPFNWrapper(model_path=MODEL_PATH_MAP["realv2_5"]),
     f"tabpfn_v2_6": lambda: TabPFNWrapper(model_path=MODEL_PATH_MAP["v2_6"]),
     f"tabpfn_v3": lambda: TabPFNWrapper(model_path=MODEL_PATH_MAP["v3"]),

--- a/scoringbench/datasets.py
+++ b/scoringbench/datasets.py
@@ -592,9 +592,53 @@ def load_dataset(dataset_config: dict) -> tuple[pd.DataFrame, pd.Series]:
 
     elif source == 'openml':
         dataset_id = dataset_config['id']
-        data = fetch_openml(data_id=dataset_id, as_frame=True, parser='auto')
-        X = data.data
-        y = data.target
+        # Datasets that have no OpenML default_target_attribute: name the
+        # documented regression target and drop co-targets / IDs / date columns
+        # so they don't leak into the features.
+        _TARGET_OVERRIDE = {
+            4531:  ("total_UPDRS", ["motor_UPDRS", "subject."]),   # Parkinsons telemonitoring
+            42989: ("actual_productivity", ["date"]),             # garment productivity
+            42897: ("Next_Tmax", ["Next_Tmin", "Date"]),          # temp-forecast bias correction
+        }
+        try:
+            data = fetch_openml(data_id=dataset_id, as_frame=True, parser='auto')
+            if dataset_id in _TARGET_OVERRIDE:
+                tgt, drop = _TARGET_OVERRIDE[dataset_id]
+                frame = data.frame
+                y = frame[tgt]
+                X = frame.drop(columns=[tgt] + [c for c in drop if c in frame.columns])
+            else:
+                X = data.data
+                y = data.target
+        except ValueError as e:
+            msg = str(e)
+            if "Sparse ARFF" in msg:
+                # High-dim sparse ARFF (e.g. molecular QSAR sets) can't be a
+                # DataFrame; load with as_frame=False and densify.
+                import scipy.sparse as _sp
+                data = fetch_openml(data_id=dataset_id, as_frame=False, parser='auto')
+                X_raw = data.data
+                X = pd.DataFrame(
+                    X_raw.toarray() if _sp.issparse(X_raw) else X_raw,
+                    columns=getattr(data, 'feature_names', None),
+                )
+                y = pd.Series(data.target)
+            elif "md5" in msg.lower():
+                # OpenML's stored file md5 disagrees with its metadata, so
+                # sklearn refuses to load it. The openml package loads the same
+                # data via its default target attribute without that check.
+                import openml as _oml
+                d = _oml.datasets.get_dataset(
+                    dataset_id, download_data=True,
+                    download_qualities=False, download_features_meta_data=True,
+                )
+                X, y, _, _ = d.get_data(
+                    target=d.default_target_attribute, dataset_format="dataframe",
+                )
+            else:
+                raise
+        if y is None:
+            raise ValueError(f"OpenML dataset {dataset_id} has no target column")
         # Convert target to numeric if needed
         if y.dtype == 'object' or isinstance(y.dtype, pd.CategoricalDtype):
             y = pd.to_numeric(y, errors='coerce')

--- a/scoringbench/wrappers/__init__.py
+++ b/scoringbench/wrappers/__init__.py
@@ -10,20 +10,30 @@ live in their own sub-modules:
 """
 
 from .base import DistributionPrediction, ProbabilisticWrapper
-from .tabpfn import TabPFNWrapper, FinetuneTabPFNWrapper
-from .tabicl import TabICLWrapper, FinetuneTabICLWrapper
-from .xgb_vector import XGBVectorWrapper, XGBQuantileVectorWrapper
-from .xgblss_wrapper import XGBLSSWrapper
-from .pytabkit import (
-    PytabkitRealMLPWrapper,
-    PytabkitRealMLPHPOWrapper,
-    PytabkitTabMDWrapper,
-    PytabkitTabMHPOWrapper,
-)
-from .catboost_wrapper import CatBoostQuantileWrapper
-from .crepes_wrapper import CrepesWrapper
+from .synthefy import SynthefyWrapper
+
+# Heavy model wrappers: import if their backing library is present, else expose
+# the name as None so the package (and run_bench_regression.py's import list)
+# loads without every competitor's stack installed. Only the models actually
+# referenced in MODELS need their library at run time.
+_OPTIONAL = [
+    ("TabPFNWrapper", "tabpfn"), ("FinetuneTabPFNWrapper", "tabpfn"),
+    ("TabICLWrapper", "tabicl"), ("FinetuneTabICLWrapper", "tabicl"),
+    ("XGBVectorWrapper", "xgb_vector"), ("XGBQuantileVectorWrapper", "xgb_vector"),
+    ("XGBLSSWrapper", "xgblss_wrapper"), ("CatBoostQuantileWrapper", "catboost_wrapper"),
+    ("CrepesWrapper", "crepes_wrapper"),
+    ("PytabkitRealMLPWrapper", "pytabkit"), ("PytabkitRealMLPHPOWrapper", "pytabkit"),
+    ("PytabkitTabMDWrapper", "pytabkit"), ("PytabkitTabMHPOWrapper", "pytabkit"),
+]
+for _name, _mod in _OPTIONAL:
+    try:
+        _m = __import__(f"scoringbench.wrappers.{_mod}", fromlist=[_name])
+        globals()[_name] = getattr(_m, _name)
+    except Exception:
+        globals()[_name] = None
 
 __all__ = [
+    "SynthefyWrapper",
     "DistributionPrediction",
     "ProbabilisticWrapper",
     "TabPFNWrapper",

--- a/scoringbench/wrappers/synthefy.py
+++ b/scoringbench/wrappers/synthefy.py
@@ -1,0 +1,85 @@
+"""Synthefy Nori wrapper for ScoringBench.
+
+Nori (https://github.com/Synthefy/synthefy-nori) is a tabular foundation model
+for regression via in-context learning. The released checkpoint has a native
+999-quantile pinball head, so the full predictive distribution is available
+through the public API (``output_type="full"``).
+
+ICL semantics: ``fit()`` just stores the labeled context rows; the frozen model
+runs in a single forward pass at ``predict``/``predict_distribution`` time.
+``predict_distribution()`` reads the model's quantile bank and maps consecutive
+quantiles to equi-probable bins (a piecewise-uniform PMF), exactly the
+representation ScoringBench's metrics consume.
+
+Requires ``synthefy-nori`` with the ``output_type="full"`` quantile API
+(>= the release that adds probabilistic output; install from source if needed).
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from .base import DistributionPrediction, ProbabilisticWrapper
+
+
+def _to_numeric(X):
+    """Coerce a DataFrame / array to a finite float32 matrix (factorize strings)."""
+    import pandas as pd
+    if isinstance(X, pd.DataFrame):
+        X = X.copy()
+        for c in X.columns:
+            if X[c].dtype == object or str(X[c].dtype).startswith("category"):
+                X[c] = pd.factorize(X[c])[0]
+        X = X.apply(pd.to_numeric, errors="coerce").to_numpy(np.float32)
+    X = np.asarray(X, dtype=np.float32)
+    return np.nan_to_num(X, nan=0.0, posinf=0.0, neginf=0.0)
+
+
+class SynthefyWrapper(ProbabilisticWrapper):
+    """Wraps ``synthefy_nori.NoriRegressor`` with the DistributionPrediction API."""
+
+    # Cap the in-context rows for speed/memory (0 = use the full training set).
+    CTX_CAP = 0
+
+    def __init__(self, device=None, model_path=None, augmentations=(), **kwargs):
+        import torch
+        from synthefy_nori import NoriRegressor
+
+        if device is None:
+            device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        # augmentations default to () — the Yeo-Johnson point ensemble has no
+        # distribution-level analogue and is bypassed on the quantile path
+        # anyway; keeping it off makes predict() and predict_distribution()
+        # consistent.
+        self._model = NoriRegressor(
+            model_path=model_path,
+            device=device,
+            augmentations=tuple(augmentations),
+            **kwargs,
+        )
+
+    def fit(self, X, y) -> "SynthefyWrapper":
+        Xn = _to_numeric(X)
+        yn = np.asarray(y, dtype=np.float64).reshape(-1)
+        if self.CTX_CAP and len(yn) > self.CTX_CAP:
+            keep = np.random.default_rng(0).choice(len(yn), self.CTX_CAP, replace=False)
+            Xn, yn = Xn[keep], yn[keep]
+        self._model.fit(Xn, yn)
+        return self
+
+    def predict(self, X) -> np.ndarray:
+        return np.asarray(
+            self._model.predict(_to_numeric(X)), dtype=np.float64
+        ).reshape(-1)
+
+    def predict_distribution(self, X) -> DistributionPrediction:
+        full = self._model.predict(_to_numeric(X), output_type="full")
+        Q = np.asarray(full["quantiles"], dtype=np.float64)  # (n, K) ascending per row
+        n, K = Q.shape
+        # K sorted quantiles -> K-1 equi-probable interior bins.
+        edges = Q                                  # (n, K) per-sample bin edges
+        mids = 0.5 * (Q[:, :-1] + Q[:, 1:])        # (n, K-1)
+        probas = np.full((n, K - 1), 1.0 / (K - 1))  # uniform mass between quantiles
+        mean = np.asarray(full["mean"], dtype=np.float64)
+        return DistributionPrediction(
+            probas=probas, bin_edges=edges, bin_midpoints=mids, mean=mean
+        )


### PR DESCRIPTION
# Add the Synthefy Nori tabular regression model (+ loader fixes for 4 datasets)

Submitted by the Synthefy team — cc @sagarwal-atg @raimishah @yogabbagabb.

## Summary

Adds [Nori](https://github.com/Synthefy/synthefy-nori), a tabular foundation model for regression via in-context learning, as a ScoringBench model. Nori's released checkpoint has a native **999-quantile pinball head**, so the full predictive distribution is available — a natural fit for proper-scoring-rule evaluation.

## Changes

- **`scoringbench/wrappers/synthefy.py`** — `SynthefyWrapper(ProbabilisticWrapper)` backed by the public `synthefy-nori` package. `fit()` stores the in-context rows; `predict_distribution()` reads the quantile bank via `predict(output_type="full")` and maps consecutive quantiles to **equi-probable bins**, yielding a `DistributionPrediction` (per-sample `bin_edges`, uniform `probas`, `mean`) the metrics consume directly. (Replaces the prior stub `synthefy.py`, which imported a private internal checkout.)
- **`run_bench_regression.py`** — register the wrapper as `"nori"` in `MODELS`.
- **`scoringbench/wrappers/__init__.py`** — make the heavy model-wrapper imports optional (degrade to `None` if their backend isn't installed), so the package imports without every competitor's library present. Only models actually referenced at run time need their backend.
- **`scoringbench/datasets.py`** — load-time fixes so the full 102-dataset suite resolves (these affect all models, not just Nori):
  - **Sparse ARFF fallback** — `QSAR-TID-11` / `QSAR-TID-10980` can't be loaded with `as_frame=True`; fall back to `as_frame=False` and densify.
  - **Target overrides** for 3 datasets with no OpenML `default_target_attribute`: `Parkinsons_Telemonitoring → total_UPDRS`, `PRODUCTIVITY → actual_productivity`, `BIAS_CORRECTION → Next_Tmax`. Co-targets and ID/date columns are dropped to avoid leakage (e.g. `motor_UPDRS`, `Next_Tmin`).
  - **Yolanda** — OpenML's stored file md5 disagrees with its metadata, so sklearn refuses to load it; fall back to the `openml` package's `get_data` (loads via the default target attribute without that check).
- **`requirements.txt`** — depend on `synthefy-nori>=0.6.0` for the `output_type="full"` quantile API (added in 0.6.0).

## Results (local autorank, 102 datasets × 5-fold CV, 40 models)

Ranked against the existing baselines with autorank (Friedman + Nemenyi, α=0.05). Companion results PR to **ScoringBenchOutput**: https://github.com/jonaslandsgesell/ScoringBenchOutput/pull/1

- **CRPS: Nr. 1 of 40** — mean-rank 2.62 vs 9.36 for Nr. 2 (tabpfn_v3); with CD = 6.59, Nori is significantly better than every other model on CRPS. Median CRPS 0.199.
- Calibration **PIT-KS Nr. 3**, 90% coverage **Nr. 6**, CRLS **Nr. 7**.
- **Honest caveat:** Nori is weak on the density/likelihood scores (log_score Nr. 36, CDE Nr. 40). This is an artifact of the equi-probable-bin mapping — a piecewise-uniform density is exact for CDF-based scores (CRPS, coverage) but crude for likelihood scores, especially in the tails. A smoother quantile→density reconstruction would likely improve those without affecting CRPS.

## Notes for reviewers

- The 4 dataset curations above may differ from your intended setup — happy to adjust targets / drops to match your conventions.
- Local rankings used baselines pulled from ScoringBenchOutput; the authoritative leaderboard is whatever your pipeline regenerates on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
