### PR TITLE
Fix negative CRPS: compute histogram energy score in float64 and clamp >= 0

### DIFF
--- a/scoringbench/metrics.py
+++ b/scoringbench/metrics.py
@@ -118,6 +118,16 @@ def compute_energy_score_histogram_corrected(
         At beta=1.0, this mathematically equals the exact continuous CRPS.
         """
         device = probas.device
+        # Promote to float64: term1 - term2 (E|X-y| minus the half self-distance)
+        # is a difference of potentially large, nearly-equal values. In float32 the
+        # catastrophic cancellation can push the (non-negative) energy score / CRPS
+        # below zero for sharp or wide-binned predictive distributions (observed:
+        # CRPS down to -5.8 on quantile-histogram models). Double precision plus the
+        # per-sample clamp below restore the mathematical guarantee score >= 0.
+        probas = probas.double()
+        bin_mids = bin_mids.double()
+        bin_widths = bin_widths.double()
+        y = y.double()
         n_samples, n_bins = probas.shape
         shared = (bin_mids.ndim == 1)
         
@@ -176,8 +186,9 @@ def compute_energy_score_histogram_corrected(
                     term2_parts.append(0.5 * torch.einsum("ci,cij,cj->c", p_c, Dc, p_c))
                 term2 = torch.cat(term2_parts)
 
-            # Average over samples
-            results[f"energy_score_beta_{beta}"] = (term1 - term2).mean().item()
+            # Average over samples (clamp per-sample: energy score / CRPS is
+            # non-negative by definition; any sub-zero value is numerical error).
+            results[f"energy_score_beta_{beta}"] = (term1 - term2).clamp(min=0).mean().item()
 
         return results
 

--- a/tests/test_crps_nonnegative.py
+++ b/tests/test_crps_nonnegative.py
@@ -1,0 +1,52 @@
+"""Regression test: CRPS / energy score must be non-negative.
+
+The histogram energy-score estimator (used for CRPS at beta=1.0) computes
+``term1 - term2`` — a difference of potentially large, nearly-equal values.
+In float32 the catastrophic cancellation drove CRPS as low as -5.8 on sharp,
+wide-binned quantile-histogram predictions (e.g. 999-quantile model heads),
+which spuriously lowered those models' mean CRPS. The estimator now runs in
+float64 and clamps per-sample to >= 0; these tests guard against regressions.
+"""
+import numpy as np
+import torch
+
+from scoringbench.metrics import compute_energy_score_histogram_corrected
+
+
+def _crps(probas, mids, widths, y, dtype=torch.float32):
+    out = compute_energy_score_histogram_corrected(
+        torch.as_tensor(probas, dtype=dtype),
+        torch.as_tensor(mids, dtype=dtype),
+        torch.as_tensor(widths, dtype=dtype),
+        torch.as_tensor(y, dtype=dtype),
+        betas=[1.0],
+    )
+    return out["energy_score_beta_1.0"]
+
+
+def test_crps_nonnegative_large_scale_sharp():
+    """Large-scale target + sharp many-bin distribution — the float32 regime
+    where term1 - term2 cancellation used to go negative."""
+    K = 1001
+    mids = np.linspace(1.0e5 - 50.0, 1.0e5 + 50.0, K)
+    widths = np.full(K, 100.0 / (K - 1))
+    probas = (np.ones(K) / K)[None, :]
+    for y in (1.0e5, 1.0e5 + 5.0, 1.0e5 - 30.0):
+        assert _crps(probas, mids, widths, [y]) >= 0.0
+
+
+def test_crps_nonnegative_random_histograms():
+    """Random valid histograms over a large dynamic range stay non-negative in
+    both float32 and float64."""
+    rng = np.random.default_rng(0)
+    for _ in range(100):
+        edges = np.unique(np.sort(rng.normal(scale=1e4, size=257)))
+        if edges.size < 3:
+            continue
+        mids = (edges[:-1] + edges[1:]) / 2.0
+        widths = np.diff(edges)
+        p = rng.random(mids.size)
+        p /= p.sum()
+        y = float(rng.normal(scale=1e4))
+        for dtype in (torch.float32, torch.float64):
+            assert _crps(p[None, :], mids, widths, [y], dtype=dtype) >= 0.0


### PR DESCRIPTION
## Problem

CRPS is computed as the histogram energy score at β=1.0
(`compute_energy_score_histogram_corrected`), as `term1 - term2` — a difference
of potentially large, nearly-equal values. In **float32** this catastrophic
cancellation can push the (mathematically non-negative) energy score / CRPS
**below zero**:

- CRPS down to **−5.8** on sharp, wide-binned quantile-histogram predictions
  (e.g. 999-quantile model heads).
- **−1e-4** even on the bundled baselines (`tabpfn_v3`, `tabiclv2`, the
  `finetune_tabpfn_*` set), and **−0.17** on `xgb_vector_quantile`.

Since CRPS ≥ 0 by definition, these are impossible values. They spuriously lower
a model's mean CRPS and create fake per-dataset "wins", biasing the leaderboard
toward models whose predictive distributions trigger the cancellation.

## Fix

Compute `term1`/`term2` in **float64** and **clamp** each per-sample score to
`>= 0` (any sub-zero value is numerical error). This applies to every β of the
energy score, all of which are non-negative.

## Test

`tests/test_crps_nonnegative.py` asserts CRPS ≥ 0 on a large-scale sharp
distribution and 100 random histograms, in both float32 and float64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
